### PR TITLE
Fixing travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
   - ./travis-tool.sh install_deps
 
 script:
-  - ./pkg-build.sh run_tests
+  - ./travis-tool.sh run_tests
 
 install_r:
   - covr

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,40 +1,36 @@
-
 language: c
 sudo: required
+dist: trusty
 
-before_install:
-  - curl -OL https://raw.githubusercontent.com/metacran/r-builder/master/pkg-build.sh
-  - chmod 755 pkg-build.sh
-  - ./pkg-build.sh bootstrap
-  - cd
-  - wget http://download.osgeo.org/gdal/2.0.1/gdal-2.0.1.tar.gz
-  - tar zxf gdal-2.0.1.tar.gz
-  - cd gdal-2.0.1
-  - ./configure --prefix=/usr
-  - make
-  - sudo make install
-  - cd
-  - wget http://download.osgeo.org/proj/proj-4.9.2.tar.gz
-  - tar zxvf proj-4.9.2.tar.gz
-  - cd proj-4.9.2
-  - ./configure --prefix=/usr
-  - make
-  - sudo make install
-  - cd /home/travis/build/earthlab/smapr
-
-install:
-  - ./pkg-build.sh install_r covr
-  - ./pkg-build.sh install_bioc rhdf5
-  - ./pkg-build.sh install_deps
+before_script:
+  - sudo apt-get --yes --force-yes update -qq
+  - sudo apt-get install -y gdal-bin libgdal-dev libgdal1-dev netcdf-bin libproj-dev libv8-dev
+  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
+  - chmod 755 ./travis-tool.sh
+  - ./travis-tool.sh bootstrap
+  - ./travis-tool.sh install_deps
 
 script:
   - ./pkg-build.sh run_tests
 
-after_success:
-  - ./pkg-build.sh run_script -e 'covr::codecov()'
+install_r:
+  - covr
 
-after_failure:
-  - ./pkg-build.sh dump_logs
+install_bioc:
+  - rhdf5
+
+env:
+   global:
+     - R_LIBS="http://cran.rstudio.com"
+     - R_BUILD_ARGS="--no-build-vignettes --no-manual"
+     - R_CHECK_ARGS="--no-build-vignettes --no-manual --as-cran"
+     - BOOTSTRAP_LATEX=""
+
+after_success:
+  - Rscript -e 'covr::codecov()'
+
+after_script:
+  - ./travis-tool.sh dump_logs
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+# following https://github.com/craigcitro/r-travis
 language: c
 sudo: required
 dist: trusty
@@ -9,15 +10,13 @@ before_script:
   - chmod 755 ./travis-tool.sh
   - ./travis-tool.sh bootstrap
   - ./travis-tool.sh install_deps
+  - ./travis-tool.sh install_bioc rhdf5
 
 script:
   - ./travis-tool.sh run_tests
 
 install_r:
   - covr
-
-install_bioc:
-  - rhdf5
 
 env:
    global:


### PR DESCRIPTION
This PR uses a new build process on Travis, so that we're no longer reliant on metacran's r-builder, using r-travis instead. Builds take 1/3 the time.