### PR TITLE
Unit tests for user specified directories

### DIFF
--- a/tests/testthat/test-download_smap.R
+++ b/tests/testthat/test-download_smap.R
@@ -16,6 +16,37 @@ test_that("non-existent directories are created", {
     unlink(dir_name, recursive = TRUE)
 })
 
+test_that("valid user-specified directories contain downloads", {
+    skip_on_cran()
+    available_data <- find_smap(id = "SPL3SMP",
+                                date = "2015-10-01",
+                                version = 4)
+    user_specified_path <- file.path('data', 'SMAP')
+    downloads <- download_smap(available_data,
+                               directory = user_specified_path)
+    expect_true(
+        file.exists(
+            file.path(user_specified_path,
+                      "SMAP_L3_SM_P_20151001_R14010_001.h5")
+            )
+        )
+    expect_true(
+        file.exists(
+            file.path(user_specified_path,
+                      "SMAP_L3_SM_P_20151001_R14010_001.h5.iso.xml")
+        )
+    )
+    expect_true(
+        file.exists(
+            file.path(user_specified_path,
+                      "SMAP_L3_SM_P_20151001_R14010_001.qa")
+        )
+    )
+
+    # clean up
+    unlink('data', recursive = TRUE, force = TRUE)
+})
+
 test_that("the downloaded data is of the data frame class", {
     skip_on_cran()
     files <- find_smap(id = "SPL3SMP", dates = "2015-03-31", version = 4)

--- a/tests/testthat/test-extract_smap.R
+++ b/tests/testthat/test-extract_smap.R
@@ -4,9 +4,11 @@ test_that("invalid datasets cause errors", {
     skip_on_cran()
     files <-  find_smap(id = "SPL3SMP", dates = "2015-03-31", version = 4)
     downloads <- download_smap(files[1, ])
-    expect_error(extract_smap(downloads,
-                              name = 'Soil_Moisture_Retrieval_Data_AM/soil_flavor',
-                              in_memory = TRUE))
+    expect_error(
+        extract_smap(downloads,
+                     name = 'Soil_Moisture_Retrieval_Data_AM/soil_flavor',
+                     in_memory = TRUE)
+        )
 })
 
 test_that("extract_smap produces a RasterStack", {
@@ -23,7 +25,8 @@ test_that("-9999 is used fill value when a _FillValue doesn't exist", {
     skip_on_cran()
     files <-  find_smap(id = "SPL3SMP", dates = "2015-03-31", version = 4)
     downloads <- download_smap(files)
-    r <- extract_smap(downloads, name = "Soil_Moisture_Retrieval_Data_PM/latitude_pm")
+    r <- extract_smap(downloads,
+                      name = "Soil_Moisture_Retrieval_Data_PM/latitude_pm")
     # the fill value in the file is -9999, but there is no fill value attribute
     # therefore, if this function works, the minimum should be >= -90
     # (the latitude at the south pole)
@@ -34,7 +37,8 @@ test_that("raster stacks are composed of raster layers", {
     skip_on_cran()
     files <-  find_smap(id = "SPL3SMP", dates = "2015-03-31", version = 4)
     downloads <- download_smap(files)
-    r <- extract_smap(downloads, name = "Soil_Moisture_Retrieval_Data_AM/latitude")
+    r <- extract_smap(downloads,
+                      name = "Soil_Moisture_Retrieval_Data_AM/latitude")
     expect_that(r[[1]], is_a("RasterLayer"))
 })
 
@@ -63,7 +67,24 @@ test_that("layer names for SPL3SMP include file name", {
     skip_on_cran()
     files <-  find_smap(id = "SPL3SMP", dates = "2015-03-31", version = 4)
     downloads <- download_smap(files)
-    r <- extract_smap(downloads, name = "Soil_Moisture_Retrieval_Data_AM/latitude")
+    r <- extract_smap(downloads,
+                      name = "Soil_Moisture_Retrieval_Data_AM/latitude")
     expected_names <- paste(downloads$name)
     expect_equal(names(r), expected_names)
+})
+
+test_that("extraction still works with user specified directories", {
+    skip_on_cran()
+    available_data <- find_smap(id = "SPL3SMP",
+                                date = "2015-10-01",
+                                version = 4)
+    user_specified_path <- file.path('data', 'SMAP')
+    downloads <- download_smap(available_data,
+                               directory = user_specified_path)
+    r <- extract_smap(downloads,
+                      name = "Soil_Moisture_Retrieval_Data_AM/latitude")
+    expect_that(r, is_a("RasterLayer"))
+
+    # clean up
+    unlink('data', recursive = TRUE, force = TRUE)
 })


### PR DESCRIPTION
Previously we allowed users to specify custom output directories
for data downloads, but did not test this feature. These unit
tests are designed to ensure that files are downloaded and
extracted without error when users specify custom output
directories. Solves #27.