### PR TITLE
Adding verbose argument to download_smap()

### DIFF
--- a/R/find_smap.R
+++ b/R/find_smap.R
@@ -32,7 +32,8 @@
 #'
 #' @param id A character string that refers to a specific SMAP dataset, e.g.,
 #'   \code{"SPL4SMGP"} for SMAP L4 Global 3-hourly 9 km Surface and Rootzone Soil
-#'   Moisture Geophysical Data.
+#'   Moisture Geophysical Data. See "Details" for a list of supported data types 
+#'   and their associated id codes.
 #' @param dates An object of class Date or a character string formatted as
 #' %Y-%m-%d (e.g., "2016-04-01") which specifies the date(s) to search.
 #' To search for one specific date, this can be a Date object of length one. To

--- a/man/download_smap.Rd
+++ b/man/download_smap.Rd
@@ -4,7 +4,7 @@
 \alias{download_smap}
 \title{Download SMAP data}
 \usage{
-download_smap(files, directory = NULL, overwrite = TRUE)
+download_smap(files, directory = NULL, overwrite = TRUE, verbose = TRUE)
 }
 \arguments{
 \item{files}{A \code{data.frame} produced by \code{find_smap()}
@@ -15,6 +15,9 @@ character string. If left as \code{NULL}, data are stored in a user's cache
 directory.}
 
 \item{overwrite}{TRUE or FALSE: should existing data files be overwritten?}
+
+\item{verbose}{TRUE or FALSE: should messages be printed to indicate that 
+files are being downloaded?}
 }
 \value{
 Returns a \code{data.frame} that appends a column called

--- a/man/find_smap.Rd
+++ b/man/find_smap.Rd
@@ -9,7 +9,8 @@ find_smap(id, dates, version)
 \arguments{
 \item{id}{A character string that refers to a specific SMAP dataset, e.g.,
 \code{"SPL4SMGP"} for SMAP L4 Global 3-hourly 9 km Surface and Rootzone Soil
-Moisture Geophysical Data.}
+Moisture Geophysical Data. See "Details" for a list of supported data types 
+and their associated id codes.}
 
 \item{dates}{An object of class Date or a character string formatted as
 %Y-%m-%d (e.g., "2016-04-01") which specifies the date(s) to search.

--- a/tests/testthat/test-download_smap.R
+++ b/tests/testthat/test-download_smap.R
@@ -121,3 +121,15 @@ test_that('input data.frames with NA values raise errors', {
                                         version = 1))
     expect_error(download_smap(df_w_na))
 })
+
+test_that('verbose = TRUE prints output', {
+  skip_on_cran()
+  files <- find_smap(id = "SPL3SMP", dates = "2015-03-31", version = 4)
+  downloads <- expect_message(download_smap(files[1, ], verbose = TRUE))
+})
+
+test_that('verbose = FALSE suppresses output', {
+  skip_on_cran()
+  files <- find_smap(id = "SPL3SMP", dates = "2015-03-31", version = 4)
+  downloads <- expect_silent(download_smap(files[1, ], verbose = FALSE))
+})


### PR DESCRIPTION
This adds an argument to download_smap() that prints which files
are being downloaded, to reassure users that things are really
happening.

Also, this includes an unrelated improvement to the documentation
for find_smap() that points users to the "Details" section for a
list of data set ids that are supported by smapr.

Solves #44